### PR TITLE
Added I18n support for exception messages

### DIFF
--- a/lib/dependent_restrict/delete_restriction_error.rb
+++ b/lib/dependent_restrict/delete_restriction_error.rb
@@ -10,21 +10,27 @@ module ActiveRecord
     end
 
     def basic_message
-      name = @name.to_s.gsub('_', ' ')
       assoc = @record.send(@name)
       count = assoc.respond_to?(:count) ? assoc.count : (assoc ? 1 : 0)
+      name = I18n.t(@name.to_s.singularize, {
+        :scope => [:activerecord, :models],
+        :count => count,
+        :default => count == 1 ? @name.to_s.gsub('_', ' ') : @name.to_s.gsub('_', ' ').pluralize
+      }).downcase
+
       if count == 1
-        "Cannot delete record because dependent #{name} exists"
+        I18n.t('dependent_restrict.basic_message.one', :name => name, :default => "Cannot delete record because dependent #{name} exists")
       else
-        "Cannot delete record because #{count} dependent #{name.pluralize} exist"
+        I18n.t('dependent_restrict.basic_message.others', :count => count, :name => name, :default => "Cannot delete record because #{count} dependent #{name.pluralize} exist")
       end
     end
 
     def detailed_message
       count = @record.send(@name).count
       examples = @record.send(@name).all(:limit => 5).map{|o| "#{o.id}: #{o.to_s}"}
-      examples[4] = "...and #{count - 4} more" if count > 5
-      basic_message + "\n\n\nThese include:\n#{examples.join("\n")}"
+      examples[4] = "...#{I18n.t('dependent_restrict.detailed_message.and_more', :count => count - 4, :default => "and #{count-4} more")}" if count > 5
+
+      basic_message + "\n\n\n#{I18n.t('dependent_restrict.detailed_message.includes', :default => "These include")}:\n#{examples.join("\n")}"
     end
   end
 end


### PR DESCRIPTION
I am not quit sure if this is something that you want on your project, but I am using it on a Rails 2 project, and i really needed those messages in pt-BR, so I just added I18n support to your project.

It's very simple to customize, there are 4 keys to be defined in order to translate:
`dependent_restrict.basic_message.one` -> message to be displayed when a single record breaks the validation, needs name variable to be defined, aka: `Cannot delete record because dependent %{name} exists`
`dependent_restrict.basic_message.others`-> message to be displayed when more than one record breaks the validation, have two variables, name and count, example: `Cannot delete record because %{count} dependent %{name} exist`

also, for more detailed message
`dependent_restrict.detailed_message.and_more`: and %{count} more
`dependent_restrict.detailed_message.includes`: These include

I also added a compatibility mode, if the Internationalization is not found, it will use the default messages that already is being used by the project.

Let me know if you need something else in it.

Regards
